### PR TITLE
feat(sync): add sync engine skeleton

### DIFF
--- a/src/services/syncEngine.js
+++ b/src/services/syncEngine.js
@@ -1,0 +1,33 @@
+function createDisabledResult(projectDoc) {
+  return {
+    status: "disabled",
+    project: projectDoc,
+  };
+}
+
+export function computeConflict({ localProject, remoteProject } = {}) {
+  return {
+    hasConflict: false,
+    reason: "not_implemented",
+    localProjectId: localProject?.project?.id || null,
+    remoteProjectId: remoteProject?.project?.id || null,
+  };
+}
+
+export async function pushProject(projectDoc) {
+  return createDisabledResult(projectDoc);
+}
+
+export async function pullProject(projectDoc) {
+  return createDisabledResult(projectDoc);
+}
+
+export async function syncProject(projectDoc) {
+  const conflict = computeConflict({ localProject: projectDoc, remoteProject: null });
+
+  return {
+    status: "disabled",
+    project: projectDoc,
+    conflict,
+  };
+}


### PR DESCRIPTION
### Motivation
- Add a minimal, non-invasive skeleton for the sync engine (U5.1) so future sync work has a clear, local-first entry point without changing current app behavior.

### Description
- Added `src/services/syncEngine.js` which exports the stubbed functions `pushProject`, `pullProject`, `syncProject`, and `computeConflict`, and returns disabled/no-op style results without touching IndexedDB or any backend.

### Testing
- Ran `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7ab3fa1c832c94b4ba29ae1add66)

## Summary by Sourcery

Nouvelles fonctionnalités :
- Ajout d’un module de service de moteur de synchronisation exposant des fonctions simulées de `push`, `pull`, `sync` et de calcul des conflits pour les projets.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a sync engine service module exposing stubbed push, pull, sync, and conflict-computation functions for projects.

</details>