### PR TITLE
feat(project): add sync status UI badge on project screen

### DIFF
--- a/src/features/projects/components/SyncStatusBadge.jsx
+++ b/src/features/projects/components/SyncStatusBadge.jsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { useI18n } from "../../../i18n/useI18n";
+
+function readConflict(sync) {
+  if (sync?.lastConflict && typeof sync.lastConflict === "object") {
+    return sync.lastConflict;
+  }
+
+  if (sync?.conflict && typeof sync.conflict === "object") {
+    return sync.conflict;
+  }
+
+  return null;
+}
+
+function resolveSyncStatus(projectDoc) {
+  const sync = projectDoc?.sync || {};
+  const conflict = readConflict(sync);
+
+  if (conflict?.hasConflict) {
+    return "conflict";
+  }
+
+  if (sync?.lastError || sync?.error) {
+    return "error";
+  }
+
+  if (sync?.dirty === true) {
+    return "dirty";
+  }
+
+  if (sync?.remoteVersion > 0 || sync?.lastSyncedAt) {
+    return "synced";
+  }
+
+  return "local_only";
+}
+
+export default function SyncStatusBadge({ projectDoc }) {
+  const { t } = useI18n();
+
+  const status = useMemo(() => resolveSyncStatus(projectDoc), [projectDoc]);
+
+  return (
+    <span className={`badge sync-badge sync-badge-${status}`}>
+      {t("project.sync.label")}: {t(`project.sync.state.${status}`)}
+    </span>
+  );
+}

--- a/src/features/projects/screens/ProjectScreen.jsx
+++ b/src/features/projects/screens/ProjectScreen.jsx
@@ -5,6 +5,7 @@ import JournalPanel from "../../../components/JournalPanel";
 import DecisionsPanel from "../../../components/DecisionsPanel";
 import AttachmentsPanel from "../../../components/AttachmentsPanel";
 import DecisionTreeModal from "../../../components/DecisionTreeModal";
+import SyncStatusBadge from "../components/SyncStatusBadge";
 import { STAGE_DEFINITIONS, getStageDefinition } from "../../../constants/stages";
 import { useI18n } from "../../../i18n/useI18n";
 
@@ -111,6 +112,7 @@ export default function ProjectScreen({
             <span className="badge">
               {currentStageDefinition?.version || project.currentStage}
             </span>
+            <SyncStatusBadge projectDoc={projectDoc} />
             <span className="muted">
               {t("project.meta.lastUpdated", {
                 timestamp: new Date(project.updatedAt).toLocaleString(),

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -182,5 +182,11 @@
   "pwa.needRefresh.title": "New version available.",
   "pwa.needRefresh.description": "Reload the app to use the latest version.",
   "pwa.actions.update": "Update",
-  "pwa.actions.close": "Close"
+  "pwa.actions.close": "Close",
+  "project.sync.label": "Sync",
+  "project.sync.state.local_only": "local only",
+  "project.sync.state.dirty": "dirty",
+  "project.sync.state.synced": "synced",
+  "project.sync.state.conflict": "conflict",
+  "project.sync.state.error": "error"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -182,5 +182,11 @@
   "pwa.needRefresh.title": "Nouvelle version disponible.",
   "pwa.needRefresh.description": "Recharge l’application pour utiliser la dernière version.",
   "pwa.actions.update": "Mettre à jour",
-  "pwa.actions.close": "Fermer"
+  "pwa.actions.close": "Fermer",
+  "project.sync.label": "Sync",
+  "project.sync.state.local_only": "local uniquement",
+  "project.sync.state.dirty": "modifications locales",
+  "project.sync.state.synced": "synchronisé",
+  "project.sync.state.conflict": "conflit",
+  "project.sync.state.error": "erreur"
 }

--- a/src/index.css
+++ b/src/index.css
@@ -653,3 +653,23 @@ select:focus {
   border-radius: 6px;
   padding: 1px 6px;
 }
+
+.sync-badge-local_only {
+  border-color: #475569;
+}
+
+.sync-badge-dirty {
+  border-color: #f59e0b;
+}
+
+.sync-badge-synced {
+  border-color: #22c55e;
+}
+
+.sync-badge-conflict {
+  border-color: #ef4444;
+}
+
+.sync-badge-error {
+  border-color: #f97316;
+}


### PR DESCRIPTION
### Motivation
- Expose a lightweight, non-invasive sync status indicator on the project screen (issue U5.3) using existing sync metadata and conflict outcomes so users can see if a project is local-only, dirty, synced, in conflict, or errored, without changing data formats or backend behavior.

### Description
- Added `SyncStatusBadge` (src/features/projects/components/SyncStatusBadge.jsx) which derives a status from `projectDoc.sync` and optional conflict/error fields and renders one of `local_only`, `dirty`, `synced`, `conflict`, or `error`.
- Integrated the badge into the project top metadata area in `ProjectScreen` (src/features/projects/screens/ProjectScreen.jsx) and added lightweight CSS variants in `src/index.css` and i18n keys in `src/i18n/en.json` and `src/i18n/fr.json` so it follows existing translation patterns.
- Implementation is strictly UI-only and preserves existing JSON import/export, PWA behavior, and store semantics; no backend sync, data-model changes, or layout redesign were introduced.
- Rollback plan: revert the commit to remove the badge, CSS, and i18n entries to restore prior state.

### Testing
- Ran `npm run build` (Vite production build) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce950efce8832cbf23d7c09dc45c12)

## Résumé par Sourcery

Ajout d’un badge visuel indiquant l’état de synchronisation sur l’écran du projet, basé sur les métadonnées de synchronisation existantes du projet.

Nouvelles fonctionnalités :
- Introduction d’un composant `SyncStatusBadge` qui déduit et affiche l’état de synchronisation d’un projet (local uniquement, modifié, synchronisé, conflit ou erreur) à partir des métadonnées de synchronisation existantes.
- Affichage du badge d’état de synchronisation à côté des métadonnées existantes du projet sur l’écran du projet.
- Ajout de libellés localisés pour les états de synchronisation en anglais et en français.

Améliorations :
- Ajout de variantes CSS pour chaque état de synchronisation afin de distinguer visuellement les différents états.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a visual sync status indicator badge to the project screen based on existing project sync metadata.

New Features:
- Introduce a SyncStatusBadge component that derives and displays a project sync state (local-only, dirty, synced, conflict, or error) from existing sync metadata.
- Show the sync status badge alongside existing project metadata on the project screen.
- Add localized labels for sync status states in English and French.

Enhancements:
- Add CSS variants for each sync status to visually distinguish different sync states.

</details>