### PR TITLE
chore(github): add manual GitHub issue seeding workflow

### DIFF
--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -1,0 +1,40 @@
+name: Seed GitHub Issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Target repository (owner/name)"
+        required: false
+        default: "Carouan/ide-projectsmanager"
+      json_path:
+        description: "Path to the JSON source of issues"
+        required: false
+        default: "scripts/github/issues.ide-projectsmanager.json"
+      dry_run:
+        description: "Run without creating issues"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Seed issues
+        shell: pwsh
+        env:
+          # Uses the built-in token; if needed, replace with a PAT secret.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Usage: run manually from Actions > "Seed GitHub Issues", then adjust inputs as needed.
+          $dryRunArg = if (${{ inputs.dry_run }}) { '-DryRun' } else { '' }
+          ./scripts/github/create_github_issues.ps1 -Repo "${{ inputs.repo }}" -JsonPath "${{ inputs.json_path }}" $dryRunArg

--- a/scripts/github/create_github_issues.ps1
+++ b/scripts/github/create_github_issues.ps1
@@ -1,41 +1,123 @@
 param(
     [string]$Repo = "Carouan/ide-projectsmanager",
-    [string]$JsonPath = "scripts/github/issues.ide-projectsmanager.json"
+    [string]$JsonPath = "scripts/github/issues.ide-projectsmanager.json",
+    [switch]$DryRun
 )
 
+function Write-Log {
+    param(
+        [string]$Message,
+        [ValidateSet("INFO", "WARN", "ERROR", "SUCCESS")]
+        [string]$Level = "INFO"
+    )
+
+    $prefix = "[{0}]" -f $Level
+    switch ($Level) {
+        "WARN" { Write-Host "$prefix $Message" -ForegroundColor Yellow }
+        "ERROR" { Write-Host "$prefix $Message" -ForegroundColor Red }
+        "SUCCESS" { Write-Host "$prefix $Message" -ForegroundColor Green }
+        default { Write-Host "$prefix $Message" }
+    }
+}
+
 if (-not $env:GITHUB_TOKEN) {
-    Write-Error "Please set GITHUB_TOKEN environment variable"
+    Write-Log "Please set GITHUB_TOKEN environment variable" "ERROR"
     exit 1
 }
 
 if (-not (Test-Path $JsonPath)) {
-    Write-Error "JSON file not found at $JsonPath"
+    Write-Log "JSON file not found at $JsonPath" "ERROR"
     exit 1
 }
 
 $headers = @{
     Authorization = "token $env:GITHUB_TOKEN"
     "User-Agent" = "codex-issue-seeder"
+    Accept = "application/vnd.github+json"
 }
 
-$issues = Get-Content $JsonPath | ConvertFrom-Json
+$issues = Get-Content -Raw $JsonPath | ConvertFrom-Json
+
+if (-not $issues -or $issues.Count -eq 0) {
+    Write-Log "No issues found in $JsonPath" "WARN"
+    exit 0
+}
+
+Write-Log "Seeding issues for repository '$Repo' from '$JsonPath'"
+if ($DryRun) {
+    Write-Log "Dry-run enabled: no issues will be created" "WARN"
+}
+
+$openIssueTitles = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+$page = 1
+
+while ($true) {
+    $openIssuesUrl = "https://api.github.com/repos/$Repo/issues?state=open&per_page=100&page=$page"
+    $openIssues = Invoke-RestMethod -Uri $openIssuesUrl -Method Get -Headers $headers
+
+    if (-not $openIssues -or $openIssues.Count -eq 0) {
+        break
+    }
+
+    foreach ($openIssue in $openIssues) {
+        if ($openIssue.pull_request) {
+            continue
+        }
+
+        [void]$openIssueTitles.Add($openIssue.title)
+    }
+
+    if ($openIssues.Count -lt 100) {
+        break
+    }
+
+    $page++
+}
+
+Write-Log "Found $($openIssueTitles.Count) open issues (excluding pull requests)"
+
+$createdCount = 0
+$skippedCount = 0
 
 foreach ($issue in $issues) {
-    Write-Host "Creating issue: $($issue.title)"
+    if (-not $issue.title) {
+        Write-Log "Skipping entry with missing title" "WARN"
+        $skippedCount++
+        continue
+    }
+
+    if ($openIssueTitles.Contains($issue.title)) {
+        Write-Log "Skipping duplicate open issue: $($issue.title)" "WARN"
+        $skippedCount++
+        continue
+    }
+
+    if ($DryRun) {
+        Write-Log "[DRY-RUN] Would create issue: $($issue.title)"
+        $createdCount++
+        continue
+    }
+
+    Write-Log "Creating issue: $($issue.title)"
 
     $body = @{
         title = $issue.title
         body  = $issue.body
     } | ConvertTo-Json -Depth 5
 
-    Invoke-RestMethod \
-        -Uri "https://api.github.com/repos/$Repo/issues" \
-        -Method Post \
-        -Headers $headers \
-        -Body $body \
-        -ContentType "application/json"
+    Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/issues" `
+        -Method Post `
+        -Headers $headers `
+        -Body $body `
+        -ContentType "application/json" | Out-Null
 
+    [void]$openIssueTitles.Add($issue.title)
+    $createdCount++
     Start-Sleep -Milliseconds 500
 }
 
-Write-Host "All issues created successfully."
+if ($DryRun) {
+    Write-Log "Dry-run completed: $createdCount issue(s) would be created, $skippedCount skipped" "SUCCESS"
+} else {
+    Write-Log "Issue seeding completed: $createdCount created, $skippedCount skipped" "SUCCESS"
+}


### PR DESCRIPTION
### Motivation
- Provide a small, reusable, manual GitHub Actions workflow to seed issues from the existing JSON source while reusing the repo's current scripts and avoiding duplicate creations when possible.

### Description
- Enhanced `scripts/github/create_github_issues.ps1` to add a `-DryRun` switch, leveled `Write-Log` output, safer `Get-Content -Raw` parsing, and open-issue title deduplication (excludes PRs and pages through API results) to reduce duplicate creations.
- Added `.github/workflows/seed-issues.yml` with a `workflow_dispatch` manual trigger and optional inputs `repo`, `json_path`, and `dry_run`, and it invokes the existing PowerShell script using the `GITHUB_TOKEN` from the workflow environment.
- Impacted files: `scripts/github/create_github_issues.ps1` and `.github/workflows/seed-issues.yml`.
- Risks: deduplication is title-based so different issues sharing the same title will be skipped, and the workflow requires `issues: write` permission or an appropriately-scoped token.
- Rollback plan: revert the change to restore the previous `create_github_issues.ps1` and remove the workflow file.

### Testing
- Ran `npm run build` and the project build completed successfully.
- Attempted a local PowerShell syntax parse (`pwsh -NoProfile -Command ...`) but it failed in this environment because `pwsh` is not installed, so a local PS syntax check was not executed here; the workflow uses `pwsh` on `ubuntu-latest` where PowerShell is available.
- Confirmed repository changes are present and script logic handles empty input and open-issue checking; no other automated tests were modified or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceab5943c4832c8eeb3f0d8b2be8e1)

## Résumé par Sourcery

Ajoute un workflow GitHub Actions manuel et améliore le script existant d’initialisation des tickets afin de peupler en toute sécurité des issues GitHub à partir d’une source JSON tout en évitant les doublons.

Nouvelles fonctionnalités :
- Introduit un workflow GitHub Actions réutilisable, déclenché manuellement, pour peupler des issues à partir d’un fichier JSON dans un dépôt cible.

Améliorations :
- Étend le script PowerShell d’initialisation des issues GitHub avec la prise en charge du mode dry-run, une journalisation structurée, une analyse JSON plus sûre et une déduplication basée sur le titre par rapport aux issues ouvertes existantes afin de réduire la création de doublons.

CI :
- Ajoute un workflow GitHub Actions `workflow_dispatch` qui invoque le script PowerShell d’initialisation des issues avec des options configurables pour le dépôt, le chemin du JSON et le mode dry-run.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a manual GitHub Actions workflow and enhance the existing issue seeding script to safely seed GitHub issues from a JSON source while avoiding duplicates.

New Features:
- Introduce a reusable, manually triggered GitHub Actions workflow for seeding issues from a JSON file into a target repository.

Enhancements:
- Extend the GitHub issue seeding PowerShell script with dry-run support, structured logging, safer JSON parsing, and title-based deduplication against existing open issues to reduce duplicate creations.

CI:
- Add a workflow_dispatch GitHub Actions workflow that invokes the issue seeding PowerShell script with configurable repository, JSON path, and dry-run options.

</details>