### PR TITLE
docs: archive local issue-seeding history and add in-repo project docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# Documentation du dépôt
+
+Cette documentation est conservée **dans le dépôt** comme source de vérité versionnée.
+
+## Pourquoi dans le dépôt plutôt que dans la wiki GitHub
+
+Pour ce projet, la documentation dans le dépôt est plus adaptée que la wiki GitHub :
+
+- elle voyage dans les branches, PR et reviews
+- elle reste synchronisée avec l'état réel du code
+- elle peut être refactorisée par petits commits via Codex
+- elle peut ensuite être publiée plus tard avec MkDocs, GitHub Pages ou un autre générateur si nécessaire
+
+La wiki GitHub pourra éventuellement servir plus tard comme **miroir simplifié** ou espace de lecture, mais pas comme source principale de vérité documentaire.
+
+## Structure
+
+- `project/` : documentation structurante du produit et du workflow
+- `history/` : archives utiles pour comprendre le cheminement du dépôt
+
+## Entrées principales
+
+- [A1 — Historique, cadrage et roadmap](project/a1-history-roadmap.md)
+- [A2 — Complétion méthodologique](project/a2-methodological-completion.md)
+- [B1 — Référence technique](project/b1-technical-reference.md)
+- [B2 — Guide d’automatisation Codex–GitHub](project/b2-codex-github-automation-guide.md)
+- [C — Glossaire et explications](project/c-glossary.md)
+- [Releases, Deployments, Packages — différences exactes](project/github-release-deployment-package-differences.md)
+
+## Issues GitHub seedées par workflow
+
+Le dépôt contient un workflow manuel **Seed GitHub Issues** et un script officiel de seed :
+
+- workflow : `.github/workflows/seed-issues.yml`
+- script : `scripts/github/create_github_issues.ps1`
+
+Le prochain lot prêt à l’emploi est conservé ici :
+
+- `scripts/github/issues.ide-projectsmanager.next-batch.json`
+
+### Procédure recommandée
+
+1. Aller dans **Actions**
+2. Ouvrir **Seed GitHub Issues**
+3. Lancer d’abord avec `dry_run = true`
+4. Vérifier les logs
+5. Relancer avec `dry_run = false`

--- a/docs/history/github-issue-seeding/2026-04-02-local-seed-script.ps1
+++ b/docs/history/github-issue-seeding/2026-04-02-local-seed-script.ps1
@@ -1,0 +1,41 @@
+param(
+    [string]$Repo = "Carouan/ide-projectsmanager",
+    [string]$JsonPath = "scripts/github/issues.ide-projectsmanager.json"
+)
+
+if (-not $env:GITHUB_TOKEN) {
+    Write-Error "Please set GITHUB_TOKEN environment variable"
+    exit 1
+}
+
+if (-not (Test-Path $JsonPath)) {
+    Write-Error "JSON file not found at $JsonPath"
+    exit 1
+}
+
+$headers = @{
+    Authorization = "token $env:GITHUB_TOKEN"
+    "User-Agent" = "codex-issue-seeder"
+    Accept = "application/vnd.github+json"
+}
+
+$issues = Get-Content -Raw $JsonPath | ConvertFrom-Json
+
+foreach ($issue in $issues) {
+    Write-Host "Creating issue: $($issue.title)"
+
+    $body = @{
+        title = $issue.title
+        body  = $issue.body
+    } | ConvertTo-Json -Depth 5
+
+    Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/issues" `
+        -Method Post `
+        -Headers $headers `
+        -Body $body `
+        -ContentType "application/json"
+
+    Start-Sleep -Milliseconds 500
+}
+
+Write-Host "All issues created successfully."

--- a/docs/history/github-issue-seeding/README.md
+++ b/docs/history/github-issue-seeding/README.md
@@ -1,0 +1,21 @@
+# Historique — seed initial des issues GitHub
+
+Ce dossier archive les fichiers qui ont servi au **premier seed local** des issues GitHub avant l’introduction du workflow GitHub Actions manuel.
+
+## Pourquoi conserver ces fichiers
+
+Ils documentent le cheminement réel du projet :
+
+- premier script local exécuté depuis PowerShell sur le laptop
+- premier lot d’issues JSON ayant servi à structurer les PR atomiques
+- transition vers une logique plus industrialisée dans le dépôt
+
+## Important
+
+Ces fichiers sont conservés comme **références historiques**.
+
+La source officielle à utiliser maintenant est :
+
+- `scripts/github/create_github_issues.ps1`
+- `.github/workflows/seed-issues.yml`
+- `scripts/github/issues.ide-projectsmanager.next-batch.json` et les futurs lots du même type

--- a/docs/project/a1-history-roadmap.md
+++ b/docs/project/a1-history-roadmap.md
@@ -1,0 +1,102 @@
+# A1 — Historique, cadrage et roadmap
+
+Ce document sert de mémoire projet côté vision, arbitrages, historique et roadmap.
+
+## Problème initial
+
+L’outil vise à éviter qu’un projet personnel dérive en notes éparses, idées non triées, pivots techniques non documentés, et reprises difficiles après interruption.
+
+L’application doit permettre de :
+
+- cadrer un projet par étapes versionnées `v0.0 → v1.0`
+- capturer les nouvelles idées sans casser le flux
+- documenter backlog, journal, décisions et pièces jointes
+- rouvrir un projet proprement plus tard
+- exporter un état durable du projet
+
+## Ce que le MVP devait démontrer
+
+Le MVP ne désigne pas une maquette jetable. Ici, il vise à prouver que :
+
+- un **ProjectDocument** peut être l’unité centrale
+- une UI React locale suffit à l’éditer
+- un projet peut être repris plus tard
+- ce projet peut être exporté durablement
+- on peut éviter d’introduire trop tôt backend, comptes réels et collaboration temps réel
+
+## État réel du dépôt
+
+Le dépôt a déjà dépassé le MVP initial.
+
+### Clairement implémenté
+
+- liste des projets
+- navigation projet / paramètres / liste
+- édition des métadonnées projet
+- navigation multi-étapes
+- backlog
+- journal
+- décisions
+- import / export JSON du projet courant
+- export Markdown
+- preview Markdown du projet complet
+- écran paramètres
+- i18n FR / EN
+- attachments v1
+- profil utilisateur local
+- `ownerId` sur les projets
+- IndexedDB avec fallback
+- métadonnées de sync
+- squelette de sync + détection de conflit + badge UI
+- base PWA
+
+### Partiellement réalisé
+
+- thème personnalisable présent mais incomplètement branché
+- arbre de décision présent mais encore à mieux cadrer fonctionnellement
+- synchronisation réelle non encore active
+- comportement PWA sur Android à clarifier
+
+### Encore manquant
+
+- export / import de tous les projets
+- chemin de travail par défaut / nominal
+- switch preview étape vs export complet
+- désactivation par défaut de la preview sur mobile
+- continuité post-`v1.0` via cycle lié ou sous-projet
+- aides contextuelles
+- splash screen
+- édition bidirectionnelle preview ↔ formulaire
+- formats d’édition / export supplémentaires
+- niveaux de complexité de l’outil
+- adaptation hors ICT
+- widgets spécialisés par étape
+
+## Repères historiques récents
+
+Merges récents confirmés dans le dépôt :
+
+- 2026-03-31 : refactor écrans, settings, i18n, preview Markdown
+- 2026-04-01 : attachments, profil utilisateur local
+- 2026-04-02 : repository layer, IndexedDB, sync metadata, sync engine skeleton, conflict detection, sync status badge, workflow de seed d’issues GitHub
+
+## Arborescence de travail locale recommandée
+
+Structure recommandée côté utilisateur :
+
+- `01_imports/json`
+- `02_exports/json`
+- `03_exports/markdown`
+- `04_attachments`
+- `05_backups`
+- `06_templates`
+- `07_archives`
+
+## Direction recommandée
+
+La suite logique du projet consiste à :
+
+1. stabiliser la documentation dans le dépôt
+2. seed de petits lots d’issues versionnés
+3. continuer à travailler par PR atomiques
+4. réserver la wiki GitHub comme miroir éventuel, pas comme source principale

--- a/docs/project/a2-methodological-completion.md
+++ b/docs/project/a2-methodological-completion.md
@@ -1,0 +1,86 @@
+# A2 — Complétion méthodologique d’un cycle de projet ICT basé sur versions
+
+Ce document joue le rôle d’**annexe méthodologique**. Il ne remplace pas le cadrage produit du dépôt ; il complète la méthode.
+
+## Rôle
+
+Il sert à enrichir le cycle `v0.0 → v1.0` avec :
+
+- des livrables par étape
+- des critères de sortie
+- des repères de qualité
+- des points de sécurité / privacité / robustesse
+- une logique plus explicite de préparation à l’exploitation
+
+## Complément du cycle
+
+Versionnement recommandé :
+
+- `v0.0` : besoin initial
+- `v0.1` : analyse exploratoire
+- `v0.2` : cadrage produit et MVP
+- `v0.3` : conception et préparation delivery
+- `v0.4` : assemblage / intégration
+- `v0.5` : POC / alpha
+- `v0.6` : correction des bugs
+- `v0.7` : beta
+- `v0.8` : stabilisation / corrections post-beta
+- `v0.9` : release candidate / recette
+- `v1.0` : première release publique
+
+## Ce que cette annexe apporte
+
+### Livrables et critères de sortie
+
+Chaque étape gagne à avoir :
+
+- un livrable explicite
+- une définition claire de terminé
+- des risques identifiés
+- une logique de validation
+
+### Gouvernance
+
+Elle aide à préciser :
+
+- qui décide
+- qui arbitre
+- qui valide
+- qui exploite / maintient ensuite
+
+### Qualité et robustesse
+
+Elle pousse à intégrer progressivement :
+
+- stratégie de tests
+- contrôle des régressions
+- règles de rollback
+- indicateurs de stabilité
+- préparation à la maintenance
+
+### Readiness ops
+
+Elle prépare la transition du simple développement vers un produit plus exploitable :
+
+- sauvegarde / restauration
+- visibilité des erreurs
+- comportements sûrs en cas de panne
+- documentation de maintenance
+
+## Positionnement dans ce dépôt
+
+Pour `ide-projectsmanager`, ce document ne doit pas être lu comme une check-list MVP obligatoire.
+
+Il sert plutôt de :
+
+- réserve méthodologique
+- cadre de montée en rigueur
+- source d’amélioration pour les futures versions
+
+## Consigne pratique
+
+Quand un point de cette annexe entre en conflit avec le principe de petites PR atomiques ou avec le périmètre réel du MVP, la priorité reste :
+
+1. préserver le noyau produit
+2. rester compatible avec les imports / exports
+3. avancer par incréments simples et réversibles

--- a/docs/project/b1-technical-reference.md
+++ b/docs/project/b1-technical-reference.md
@@ -1,0 +1,187 @@
+# B1 — Référence technique du projet
+
+Ce document décrit l’application elle-même : architecture, modèle de données, état réel d’implémentation, limites et roadmap technique.
+
+## Résumé technique
+
+L’application est une PWA locale développée avec React et Vite, centrée sur un fonctionnement **local-first** et **sans backend de production** à ce stade.
+
+Principes structurants :
+
+- frontend only pour le noyau actuel
+- aucune vraie authentification distante
+- aucune collaboration temps réel réelle
+- JSON comme support d’échange principal
+- export Markdown comme sortie documentaire lisible
+- persistance locale robuste
+- architecture prête à accueillir sync future, profils utilisateurs plus poussés et extensions métier
+
+## Stack actuelle
+
+- React
+- Vite
+- `vite-plugin-pwa`
+- import / export JSON
+- export / preview Markdown
+- persistance locale
+- i18n FR / EN
+- IndexedDB
+- couche repository de stockage
+
+## Architecture fonctionnelle actuelle
+
+### Écrans principaux
+
+- liste / tableau de bord des projets
+- écran projet
+- écran paramètres
+
+### Sous-zones de l’écran projet
+
+- métadonnées projet
+- navigation entre étapes
+- édition de l’étape active
+- backlog
+- journal
+- décisions
+- attachments
+- import / export
+- badge de synchronisation
+- panneau latéral de preview Markdown
+
+## Modèle de données de référence
+
+Le cœur de l’application reste un **ProjectDocument**.
+
+Structure logique :
+
+- `project`
+- `stages`
+- `backlog`
+- `journal`
+- `decisions`
+- `attachments`
+- `settings`
+- `sync`
+
+Champs importants :
+
+### `project`
+- `id`
+- `slug`
+- `title`
+- `summary`
+- `description`
+- `status`
+- `createdAt`
+- `updatedAt`
+- `ownerId`
+- `currentStage`
+
+### `stages`
+Chaque étape versionnée peut porter :
+
+- `version`
+- `title`
+- `status`
+- `goal`
+- `notes`
+- `deliverable`
+- `definitionOfDone`
+- `linkedBacklogIds`
+- `linkedJournalIds`
+
+### `attachments`
+Types prévus :
+
+- `url`
+- `note`
+- `snippet`
+- `file_ref`
+
+### `sync`
+Métadonnées préparatoires à la synchronisation :
+
+- `localVersion`
+- `remoteVersion`
+- `lastSyncedAt`
+- `dirty`
+
+## État réel d’implémentation
+
+### Noyau produit
+Implémenté :
+
+- création, ouverture, suppression de projet
+- édition des métadonnées projet
+- navigation multi-étapes
+- édition des champs d’étape
+- backlog
+- journal
+- décisions
+- arbre de décision / capture d’idée
+- export JSON
+- import JSON
+- export Markdown
+- preview Markdown intégré
+- attachments
+- base PWA
+
+### Paramètres / UX
+Implémenté :
+
+- écran paramètres
+- persistance de la langue
+- persistance du toggle preview Markdown
+- structure de settings globale
+
+Encore incomplet :
+
+- thème réellement appliqué partout
+- densité UI réellement exploitée
+- formats d’export multiples réellement branchés
+- chemins par défaut import / export / attachments
+
+### Persistances
+Implémenté :
+
+- repository layer
+- migration projets vers IndexedDB
+- migration settings + user profile vers IndexedDB
+- fallback legacy localStorage
+- hydratation asynchrone robuste
+- `ownerId`
+- profil utilisateur local minimal
+
+### Synchronisation
+Implémenté / préparé :
+
+- métadonnées `sync`
+- squelette `syncEngine`
+- calcul explicite de conflit minimal
+- badge UI d’état de sync
+
+Non fait :
+
+- push réel distant
+- pull réel distant
+- politique de fusion avancée
+- résolution de conflit assistée par UI
+- stockage / transport distant réel
+
+## Limites connues
+
+- comportement de mise à jour / réinstallation PWA à clarifier sur Android
+- besoin d’un switch `stage preview` ↔ `full export`
+- settings présents dans le modèle mais encore partiellement branchés
+- convention de dossier de travail utilisateur encore à formaliser
+- gestion de vrais fichiers binaires pour attachments non encore traitée
+
+## Roadmap technique courte recommandée
+
+1. stabiliser la v1.0 réellement livrée
+2. auditer modèle ↔ UI ↔ exports
+3. finaliser les settings réellement branchés
+4. clarifier identité / update PWA
+5. ajouter export / import global de tous les projets
+6. ajouter preview `étape active` vs `export complet`

--- a/docs/project/b2-codex-github-automation-guide.md
+++ b/docs/project/b2-codex-github-automation-guide.md
@@ -1,0 +1,166 @@
+# B2 — Guide d’automatisation Codex–GitHub
+
+Ce document répond à la question : **comment faire évoluer proprement le dépôt avec un maximum d’automatisation raisonnable ?**
+
+## Workflow cible
+
+Chaîne d’automatisation visée :
+
+1. définir un lot de travail dans un fichier JSON d’issues
+2. injecter ce lot dans GitHub
+3. traiter chaque issue individuellement avec Codex
+4. produire une branche dédiée
+5. ouvrir une PR petite, testable et réversible
+6. merger seulement si le scope est clair, validé et documenté
+7. garder le dépôt comme source de vérité des changements réellement livrés
+
+## Pourquoi ce workflow existe
+
+Il vise à éviter :
+
+- la perte de vue d’ensemble
+- les PR trop grosses
+- les prompts Codex sans cadre stable
+- les changements sans rollback explicite
+- les dérives par rapport au besoin initial
+- la casse du format des projets ou des imports / exports
+
+## Source de vérité des tâches
+
+Chaque entrée d’issue suit un format simple :
+
+```json
+{
+  "title": "F1.1 - Introduce AppShell layout",
+  "body": "## Objective\n...\n## Tasks\n...\n## Validation\n...\n## Rollback\n..."
+}
+```
+
+Bonnes pratiques :
+
+- un titre court et stable
+- un objectif clair
+- des tâches concrètes
+- des contraintes explicites
+- une section validation
+- une section rollback
+- pas de body flou ni narratif
+
+## Script et workflow officiels
+
+Le dépôt contient maintenant :
+
+- `scripts/github/create_github_issues.ps1`
+- `.github/workflows/seed-issues.yml`
+
+Le workflow manuel **Seed GitHub Issues** permet de lancer le seed depuis l’onglet Actions sans dépendre d’un terminal local.
+
+Inputs :
+
+- `repo`
+- `json_path`
+- `dry_run`
+
+## Cycle opératoire recommandé
+
+### Préparer le lot
+
+- écrire ou mettre à jour le fichier JSON d’issues
+- vérifier titres, bodies et granularité
+- s’assurer qu’une issue = un objectif unique
+
+### Créer les issues
+
+- lancer d’abord le workflow en `dry_run = true`
+- lire les logs
+- corriger si besoin
+- relancer avec `dry_run = false`
+
+### Traiter une issue avec Codex
+
+- ouvrir le dépôt
+- sélectionner une issue
+- donner à Codex un prompt strict
+- imposer une branche dédiée
+- imposer une PR petite et documentée
+
+### Valider et merger
+
+- build OK
+- scope respecté
+- validation manuelle explicite
+- rollback possible
+- merge seulement si la PR reste lisible
+
+## Règles impératives pour Codex
+
+- une branche dédiée par PR
+- une PR = un objectif unique
+- ne pas mélanger refactor structurel et feature métier
+- préserver le comportement existant sauf changement explicitement voulu
+- build obligatoire avant proposition de PR
+- ne jamais casser les imports / exports JSON
+- toute migration de données doit être expliquée
+- toute PR doit documenter risques, validation et rollback
+
+## Politique de taille des PR
+
+- viser petit
+- refuser les PR monolithiques
+- scinder si plusieurs thèmes apparaissent
+- éviter les mélanges architecture + données + feature
+
+## Prompt minimal réutilisable
+
+```text
+Analyze the repository and read AGENTS.md carefully.
+
+Implement GitHub issue: "<ISSUE TITLE>".
+
+Constraints:
+- keep implementation minimal
+- do not expand scope
+- preserve existing behavior
+
+Expected result:
+- <3 bullets max>
+
+If the current session is not write-enabled, stop immediately and say so clearly.
+Otherwise:
+- implement
+- validate
+- commit
+- push
+- create PR
+```
+
+## Conventions de nommage
+
+### Branches
+
+Formats recommandés :
+
+- `feat/front-01-app-shell`
+- `feat/front-02-settings-slice`
+- `feat/front-03-i18n-core`
+- `feat/front-04-markdown-preview`
+- `feat/sync-01-user-profile`
+- `feat/sync-02-storage-abstraction`
+
+### Commits
+
+Utiliser des **Conventional Commits** :
+
+- `feat(front): add app shell layout`
+- `feat(settings): persist ui settings`
+- `feat(markdown): add right panel preview`
+- `feat(sync): add project sync metadata`
+
+## État actuel recommandé
+
+Pour ce dépôt, la bonne pratique est maintenant :
+
+- de considérer le script du repo comme version officielle
+- d’archiver le vieux seed local comme historique
+- d’ajouter les nouveaux lots dans `scripts/github/`
+- d’utiliser GitHub Actions comme point d’entrée normal du seed d’issues

--- a/docs/project/c-glossary.md
+++ b/docs/project/c-glossary.md
@@ -1,0 +1,242 @@
+# C — Explications et glossaire
+
+Ce document sert d’onboarding, de clarification terminologique et de référence rapide.
+
+## IDE de projet personnel
+
+Ici, “IDE” ne veut pas dire IDE de code classique.
+
+Il désigne un **environnement intégré de gestion et de structuration de projet**.
+
+Il sert à :
+
+- cadrer
+- suivre
+- documenter
+- exporter
+- reprendre un projet plus tard
+
+## ProjectDocument
+
+Le **ProjectDocument** est le document racine d’un projet.
+
+C’est la vraie unité de travail. L’interface React ne fait que l’éditer.
+
+Structure typique :
+
+```json
+{
+  "schemaVersion": "1.0",
+  "project": {},
+  "stages": {},
+  "backlog": [],
+  "journal": [],
+  "decisions": [],
+  "attachments": [],
+  "settings": {},
+  "sync": {}
+}
+```
+
+## MVP
+
+Dans ce projet, le **MVP** désigne la plus petite version capable de démontrer que l’outil a une valeur réelle.
+
+Ce n’est pas :
+
+- une maquette cosmétique
+- une version parfaite
+- une version déjà cloud / collaborative / enterprise
+
+C’est :
+
+- une version exploitable
+- une version qui prouve la logique du produit
+- une version volontairement limitée
+
+## Stages
+
+Les **stages** sont les étapes `v0.0 → v1.0`.
+
+Elles servent à suivre l’avancement avec une logique de cycle.
+
+Exemples :
+
+- `v0.0` = problème initial
+- `v0.2` = formalisation du MVP
+- `v0.4` = assemblage
+- `v1.0` = première release fonctionnelle
+
+## Backlog
+
+Le **backlog** contient ce qui doit être capturé sans interrompre le flux principal :
+
+- idées futures
+- améliorations
+- tâches non prioritaires
+- chantiers reportés
+
+Formule utile : **capturer sans dériver**.
+
+## Journal
+
+Le **journal** est la mémoire chronologique du projet.
+
+Il répond à la question : **qu’est-ce qui s’est passé, quand, et pourquoi ?**
+
+Il sert à noter :
+
+- décisions
+- comptes-rendus de session
+- pistes de réflexion
+- extraits utiles
+- impacts constatés
+
+## Décisions
+
+Le bloc **décisions** formalise les arbitrages importants :
+
+- contexte
+- décision retenue
+- conséquences
+
+Quand la décision mérite une trace durable, elle peut devenir une **ADR**.
+
+## Attachments v1
+
+Les **attachments** sont des pièces jointes légères ou des références structurées liées à un projet.
+
+Types actuellement prévus :
+
+- `url`
+- `note`
+- `snippet`
+- `file_ref`
+
+Ce ne sont pas encore de vrais binaires gérés comme dans une application desktop complète.
+
+## Settings
+
+Les **settings** sont les préférences d’interface et de comportement.
+
+Exemples :
+
+- langue
+- thème
+- preview Markdown
+- densité UI
+- format d’export
+- autosave
+
+Un réglage peut être présent dans le modèle sans être encore pleinement exploité dans l’UI.
+
+## Preview Markdown
+
+Le **preview Markdown** est le panneau d’aperçu latéral.
+
+Historique important :
+
+- preview minimal
+- puis preview de l’étape active
+- puis preview du projet complet via le même export que le téléchargement
+
+Conséquence : un switch **étape / export complet** devient un vrai besoin fonctionnel.
+
+## PWA
+
+**PWA** signifie *Progressive Web App*.
+
+Dans ce projet, cela veut dire :
+
+- installable
+- utilisable comme app locale
+- service worker
+- prompt d’update
+
+## localStorage et IndexedDB
+
+- `localStorage` : simple, rapide, mais limité
+- `IndexedDB` : plus robuste pour une app qui évolue
+
+Le projet utilise désormais **IndexedDB comme stockage principal** avec fallback legacy.
+
+## Repository de stockage
+
+La couche repository sert à découpler le store du détail technique `localStorage vs IndexedDB`.
+
+Cela facilite :
+
+- migration
+- test
+- évolution future
+
+## UserProfile local
+
+Le **profil utilisateur local** est une identité minimale créée côté client.
+
+Il sert à :
+
+- identifier le propriétaire logique local
+- préparer `ownerId`
+- préparer la suite sync / multi-user
+
+## ownerId
+
+`ownerId` est l’identifiant persistant du propriétaire logique d’un projet.
+
+Il remplace une logique plus floue de simple nom affiché.
+
+## Métadonnées de synchronisation
+
+Le bloc `sync` contient des informations minimales comme :
+
+- `localVersion`
+- `remoteVersion`
+- `lastSyncedAt`
+- `dirty`
+
+Il prépare une synchronisation future sans signifier qu’elle est déjà pleinement active.
+
+## Readiness ops
+
+**Readiness ops** = niveau de préparation du produit pour être exploité dans des conditions plus sérieuses :
+
+- sauvegarde / restauration
+- états d’erreur visibles
+- robustesse de persistance
+- préparation maintenance
+- comportements sûrs en cas de panne
+
+## ADR
+
+**ADR** signifie *Architecture Decision Record*.
+
+Structure courte typique :
+
+- contexte
+- décision
+- alternatives
+- conséquences
+
+Exemples adaptés au projet :
+
+- React + PWA plutôt que backend immédiat
+- IndexedDB plutôt que localStorage seul
+- preview projet complet plutôt que preview d’étape uniquement
+
+## QuadraFrame
+
+**QuadraFrame** est la logique méthodologique A / B / C / D.
+
+Dans ce projet :
+
+- **A** = historique, vision, arbitrages, roadmap
+- **B** = architecture, implémentation, workflow technique
+- **C** = explications, onboarding, glossaire
+- **D** = export vivant du projet
+
+## Chemin de travail par défaut
+
+Le **chemin de travail par défaut** est le dossier préféré où l’utilisateur souhaite ranger imports, exports, attachments et backups.
+
+Dans une simple web app, ce chemin n’est pas manipulable comme dans une application desktop native sans API spécifique supplémentaire du navigateur.

--- a/docs/project/github-release-deployment-package-differences.md
+++ b/docs/project/github-release-deployment-package-differences.md
@@ -1,0 +1,71 @@
+# Releases, Deployments, Packages — différences exactes
+
+Ces trois notions parlent toutes de sortie ou de publication, mais elles ne désignent pas la même chose.
+
+## Release
+
+Une **release** est une **version publiée du projet**, côté produit / distribution.
+
+Elle sert à :
+
+- marquer un jalon stable
+- publier des notes de version
+- proposer éventuellement des fichiers à télécharger
+
+Exemples utiles pour ce projet :
+
+- `v0.4.0` : preview Markdown + settings + i18n
+- `v0.5.0` : attachments + user profile + storage layer
+- `v0.6.0` : sync metadata + sync UI
+
+Règle simple : **release = version officielle publiée**.
+
+## Deployment
+
+Un **deployment** est une **mise en ligne technique** vers un environnement d’exécution.
+
+Exemples :
+
+- `production`
+- `staging`
+- `preview`
+- `github-pages`
+
+Dans ce dépôt, GitHub Pages correspond à cette logique de deployment.
+
+Règle simple : **deployment = mise en ligne technique**.
+
+## Package
+
+Un **package** est un **artefact publié dans un registre de paquets**.
+
+Exemples classiques :
+
+- package npm
+- image Docker / OCI
+- package NuGet
+- package Maven
+
+Pour une app Vite/React publiée sur GitHub Pages, cette notion n’est pas centrale pour l’instant.
+
+Règle simple : **package = artefact réutilisable par d’autres systèmes**.
+
+## Vue synthétique
+
+| Notion | Rôle | Exemple ici |
+|---|---|---|
+| Release | version officielle publiée | `v0.5.0` avec notes de version |
+| Deployment | mise en ligne technique | build déployé sur `github-pages` |
+| Package | artefact publié dans un registre | pas prioritaire pour l’instant |
+
+## Recommandation pour ce dépôt
+
+À faire :
+
+1. protéger `main`
+2. continuer à utiliser GitHub Pages pour les déploiements
+3. commencer à créer des releases à chaque gros jalon fonctionnel
+
+Pas nécessaire immédiatement :
+
+- packages, sauf si le projet devient un composant npm, une image Docker ou une librairie réutilisable

--- a/scripts/github/issues.ide-projectsmanager.next-batch.json
+++ b/scripts/github/issues.ide-projectsmanager.next-batch.json
@@ -1,0 +1,30 @@
+[
+  {
+    "title": "R1.1 - Add Markdown preview mode switch",
+    "body": "## Objective\nLet users switch the right-panel Markdown preview between:\n- active stage preview\n- full project export preview\n\n## Tasks\n- add a small preview mode setting\n- keep the existing full-project preview as one mode\n- restore a stage-scoped preview builder for the active stage\n- wire the preview panel to the selected mode\n\n## Constraints\n- preserve the current Markdown export format\n- do not redesign the Markdown renderer\n- do not add section navigation or collapsible blocks yet\n\n## Validation\n- users can switch between stage and full preview\n- the full preview still matches the Markdown export\n- the stage preview follows the active stage\n- build passes\n\n## Rollback\n- revert preview mode setting and panel wiring"
+  },
+  {
+    "title": "R1.2 - Add nominal workspace path settings",
+    "body": "## Objective\nAdd a lightweight way for users to define their preferred workspace conventions for:\n- JSON imports\n- JSON exports\n- Markdown exports\n- attachments\n\n## Tasks\n- add settings fields for nominal/preferred paths or folder labels\n- surface these values in the Settings screen\n- show them in export/import related UI where helpful\n- keep values local-only\n\n## Constraints\n- do not promise true filesystem write access\n- do not introduce browser-specific file APIs beyond current behavior\n- keep the feature informational/configurational for now\n\n## Validation\n- settings persist across reloads\n- preferred workspace values are visible in the UI\n- no regression in current import/export flows\n- build passes\n\n## Rollback\n- revert nominal workspace settings and related UI hints"
+  },
+  {
+    "title": "R1.3 - Clarify decision tree destinations and handoff actions",
+    "body": "## Objective\nMake the decision tree outcomes clearer and more actionable inside the app.\n\n## Tasks\n- review existing destination outcomes\n- make destination labels and explanations explicit in the UI\n- clarify the handoff action for each destination (backlog, reframe, new project, architectural note, technical note)\n- keep the current routing minimal and deterministic\n\n## Constraints\n- do not redesign the whole modal\n- do not change project data structures unless strictly necessary\n- preserve current decision-tree logic unless a small fix is required for consistency\n\n## Validation\n- each destination has a clear in-app explanation\n- each destination has a clear next action\n- no regression in existing decision-tree flow\n- build passes\n\n## Rollback\n- revert decision-tree wording and handoff changes"
+  },
+  {
+    "title": "R1.4 - Apply theme setting across the app shell",
+    "body": "## Objective\nMake the existing `theme` setting actually affect the application consistently.\n\n## Tasks\n- define the minimal supported themes (for example dark / light, or current / light)\n- connect the stored setting to top-level CSS or document attributes\n- ensure major layout areas follow the selected theme\n- keep the implementation small and reversible\n\n## Constraints\n- do not redesign the product UI\n- do not introduce a large theming framework\n- keep existing settings compatibility\n\n## Validation\n- changing the theme updates the application visibly\n- theme choice persists after refresh\n- app remains readable in supported themes\n- build passes\n\n## Rollback\n- revert theme wiring while preserving stored settings"
+  },
+  {
+    "title": "R1.5 - Clarify PWA identity and update behavior",
+    "body": "## Objective\nReduce ambiguity around install/update behavior for the PWA, especially on mobile.\n\n## Tasks\n- review manifest identity fields (`name`, `short_name`, `id`, `start_url`, `scope`)\n- document the intended update flow in the repo\n- make the in-app update prompt wording explicit if needed\n- keep runtime changes minimal and focused\n\n## Constraints\n- do not introduce a backend\n- do not change unrelated app behavior\n- avoid broad PWA refactors unless required by the identity fix\n\n## Validation\n- manifest identity is coherent\n- update behavior is documented clearly\n- prompt/update UX remains functional\n- build passes\n\n## Rollback\n- revert manifest and prompt wording changes"
+  },
+  {
+    "title": "R1.6 - Add export for all projects as one JSON bundle",
+    "body": "## Objective\nAllow users to export all stored projects in one JSON bundle for backup or transfer.\n\n## Tasks\n- add an export-all action in Settings or another appropriate global location\n- serialize all projects with a small bundle wrapper or a clearly documented array format\n- keep per-project export untouched\n\n## Constraints\n- preserve existing single-project export behavior\n- keep the format simple and documented\n- avoid changing project schema unnecessarily\n\n## Validation\n- all current projects can be exported in one file\n- single-project export still works\n- bundle content is valid JSON\n- build passes\n\n## Rollback\n- revert the export-all action and serializer"
+  },
+  {
+    "title": "R1.7 - Add import for project bundle restore",
+    "body": "## Objective\nAllow users to restore a previously exported multi-project JSON bundle.\n\n## Tasks\n- add an import path for the global project bundle\n- validate imported structure safely\n- merge or insert imported projects with predictable behavior\n- surface simple import errors to the user\n\n## Constraints\n- do not silently overwrite projects\n- preserve existing single-project import behavior where possible\n- keep validation minimal but explicit\n\n## Validation\n- a valid bundle restores multiple projects\n- invalid bundle structure fails safely\n- no silent overwrite occurs\n- build passes\n\n## Rollback\n- revert bundle import handling"
+  }
+]


### PR DESCRIPTION
### Motivation
- Preserve the initial local issue-seeding artifacts as repository history instead of leaving them only on the laptop.
- Move the project’s explanatory/reference material into the repository so documentation can be reviewed in PRs, versioned with the codebase, and used as the source of truth.
- Prepare the next issue-seeding batch directly in `scripts/github/` so the existing manual GitHub Actions workflow can be used without relying on a local terminal.

### Description
- Added `docs/README.md` as the in-repo documentation index and positioned repo docs as the primary documentation source, with GitHub wiki explicitly treated as optional later mirror material rather than the main source of truth.
- Added `docs/history/github-issue-seeding/` with a historical README and the original local PowerShell seed script used before the workflow-based approach.
- Added repository-friendly project docs under `docs/project/`:
  - `a1-history-roadmap.md`
  - `a2-methodological-completion.md`
  - `b1-technical-reference.md`
  - `b2-codex-github-automation-guide.md`
  - `c-glossary.md`
  - `github-release-deployment-package-differences.md`
- Added `scripts/github/issues.ide-projectsmanager.next-batch.json` so the next issue batch is versioned in the repo and ready for `Seed GitHub Issues`.

### Notes
- This PR intentionally favors **docs-in-repo** over GitHub wiki for now because docs in the repo are branchable, reviewable, and version-aligned with code changes.
- I did **not** replace the official repo seed script; the archived local script is kept as historical context only.
- I did **not** update the root `README.md` in this PR, to keep scope narrower and avoid mixing repository documentation integration with existing file edits.
- I did **not** archive the full original historical issue JSON yet; the branch already captures the script history plus the next official batch to be used going forward.

### How to use after merge
- Open **Actions** → **Seed GitHub Issues**
- Keep `repo = Carouan/ide-projectsmanager`
- Set `json_path = scripts/github/issues.ide-projectsmanager.next-batch.json`
- Run first with `dry_run = true`
- If logs are correct, run again with `dry_run = false`

### Validation
- Changes are documentation and JSON/script additions only; no runtime code paths were modified.
- Existing issue-seeding workflow path remains unchanged and gains a repo-versioned next batch file.

### Rollback
- Revert this PR to remove the added docs/history files and next-batch JSON if the repository documentation layout needs to be redesigned.

## Summary by Sourcery

Ajouter la documentation du projet dans le dépôt et archiver les premiers artefacts locaux de pré-remplissage des issues GitHub, tout en préparant le prochain lot d’issues pour le workflow de pré-remplissage existant.

Documentation :
- Introduire un index de documentation et une structure qui positionnent la documentation dans le dépôt comme source de vérité principale et versionnée.
- Ajouter une documentation détaillée du projet couvrant l’historique/feuille de route, les orientations méthodologiques, la référence technique, le workflow d’automatisation avec GitHub/Codex, le glossaire, ainsi que les concepts de release/déploiement/package.
- Archiver les notes historiques de pré-remplissage des issues GitHub et le script PowerShell local original de pré-remplissage afin de préserver le contexte des premiers workflows dans le dépôt.

Tâches diverses :
- Versionner le prochain lot JSON d’issues GitHub sous `scripts/github/` afin qu’il puisse être consommé directement par le workflow existant Seed GitHub Issues.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add in-repo project documentation and archive the initial local GitHub issue-seeding artifacts while preparing the next issue batch for the existing seeding workflow.

Documentation:
- Introduce a docs index and structure that positions in-repo documentation as the primary, versioned source of truth.
- Add detailed project documentation covering history/roadmap, methodological guidance, technical reference, automation workflow with GitHub/Codex, glossary, and release/deployment/package concepts.
- Archive historical GitHub issue-seeding notes and the original local PowerShell seed script to preserve early workflow context in the repository.

Chores:
- Version the next GitHub issue batch JSON under scripts/github/ so it can be consumed directly by the existing Seed GitHub Issues workflow.

</details>